### PR TITLE
Account for salts during cracking

### DIFF
--- a/bf_crack.go
+++ b/bf_crack.go
@@ -74,7 +74,7 @@ var bfCrack = &cli.Command{
 			}
 
 			fmt.Printf("%s     ", shortHash(item.Hash))
-			res := bf.Crack(item.Hash, s)
+			res := bf.Crack(item.Hash, item.Salt, s)
 			if !res.Ok {
 				fmt.Println("no match")
 				continue

--- a/bruteforce/bruteforce.go
+++ b/bruteforce/bruteforce.go
@@ -1,7 +1,7 @@
 package bruteforce
 
 type Interface interface {
-	Crack(in []byte, s *Strategy) *Result
+	Crack(hash []byte, salt []byte, s *Strategy) *Result
 }
 
 type Bruteforce struct{}

--- a/bruteforce/crack.go
+++ b/bruteforce/crack.go
@@ -31,7 +31,7 @@ type Result struct {
 	Time     time.Duration
 }
 
-func (b *Bruteforce) Crack(hash []byte, s *Strategy) *Result {
+func (b *Bruteforce) Crack(hash []byte, salt []byte, s *Strategy) *Result {
 	start := time.Now()
 
 	var chars []byte
@@ -53,7 +53,8 @@ func (b *Bruteforce) Crack(hash []byte, s *Strategy) *Result {
 
 	i := 1
 	for {
-		x := s.Cipher.Hash(curr)
+		salted := append(curr, salt...)
+		x := s.Cipher.Hash(salted)
 		if bytes.Equal(hash, x) {
 			time := time.Now().Sub(start)
 			return &Result{

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -69,7 +69,15 @@ func (ds *Dataset) Next() (*Item, error) {
 
 	record := bytes.Split(line, delimiter)
 
-	hash, err := decodeHex(record[0])
+	var hexHash, salt []byte
+	hexHash = record[0]
+
+	// Use salt if present in the dataset
+	if len(record) == 2 {
+		salt = record[1]
+	}
+
+	hash, err := decodeHex(hexHash)
 	if err != nil {
 		return nil, fmt.Errorf("decodeHex: %w", err)
 	}
@@ -77,7 +85,7 @@ func (ds *Dataset) Next() (*Item, error) {
 	ds.LinesRead++
 	return &Item{
 		Hash: hash,
-		Salt: record[1],
+		Salt: salt,
 	}, nil
 }
 

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -48,6 +48,7 @@ func (ds *Dataset) HasNext() bool {
 	if err != nil {
 		return false
 	}
+	ds.file.Close()
 	return true
 }
 
@@ -59,6 +60,7 @@ type Item struct {
 func (ds *Dataset) Next() (*Item, error) {
 	line, _, err := ds.reader.ReadLine()
 	if err == io.EOF {
+		ds.file.Close()
 		return nil, err
 	}
 	if err != nil {

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -52,9 +52,8 @@ func (ds *Dataset) HasNext() bool {
 }
 
 type Item struct {
-	Username string
-	Hash     []byte
-	Salt     []byte
+	Hash []byte
+	Salt []byte
 }
 
 func (ds *Dataset) Next() (*Item, error) {
@@ -68,16 +67,15 @@ func (ds *Dataset) Next() (*Item, error) {
 
 	record := bytes.Split(line, delimiter)
 
-	hash, err := decodeHex(record[1])
+	hash, err := decodeHex(record[0])
 	if err != nil {
 		return nil, fmt.Errorf("decodeHex: %w", err)
 	}
 
 	ds.LinesRead++
 	return &Item{
-		Username: string(record[0]),
-		Hash:     hash,
-		Salt:     record[2],
+		Hash: hash,
+		Salt: record[1],
 	}, nil
 }
 

--- a/dict_crack.go
+++ b/dict_crack.go
@@ -62,7 +62,7 @@ var dictCrack = &cli.Command{
 			}
 
 			fmt.Printf("%s     ", shortHash(item.Hash))
-			res := di.Crack(item.Hash, s)
+			res := di.Crack(item.Hash, item.Salt, s)
 			if !res.Ok {
 				fmt.Println("no match")
 				continue

--- a/dictionary/crack.go
+++ b/dictionary/crack.go
@@ -20,11 +20,12 @@ type Result struct {
 }
 
 // Crack tries to find the original password using the loaded dictionary
-func (d *Dictionary) Crack(hash []byte, s *Strategy) *Result {
+func (d *Dictionary) Crack(hash []byte, salt []byte, s *Strategy) *Result {
 	start := time.Now()
 
 	for i, w := range d.Words {
-		h := s.Cipher.Hash(w)
+		salted := append(w, salt...)
+		h := s.Cipher.Hash(salted)
 		if bytes.Equal(hash, h) {
 			time := time.Now().Sub(start)
 			return &Result{

--- a/dictionary/dictionary.go
+++ b/dictionary/dictionary.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Interface interface {
-	Crack(hash []byte, s *Strategy) *Result
+	Crack(hash []byte, salt []byte, s *Strategy) *Result
 }
 
 type Dictionary struct {


### PR DESCRIPTION
Account for salts when cracking. Additionally, remove unused `username` field in dataset record model.