### PR TITLE
Update brute force flags

### DIFF
--- a/bf_crack.go
+++ b/bf_crack.go
@@ -31,7 +31,6 @@ var bfCrack = &cli.Command{
 		&cli.BoolFlag{
 			Name:    "lowercase",
 			Aliases: []string{"lc"},
-			Value:   true,
 		},
 		&cli.BoolFlag{
 			Name:    "uppercase",

--- a/bf_crack.go
+++ b/bf_crack.go
@@ -24,6 +24,10 @@ var bfCrack = &cli.Command{
 			Aliases: []string{"max"},
 			Value:   4,
 		},
+		&cli.IntFlag{
+			Name:    "min-length",
+			Aliases: []string{"min"},
+		},
 		&cli.StringFlag{
 			Name:  "cipher",
 			Value: "sha256",
@@ -62,6 +66,7 @@ var bfCrack = &cli.Command{
 			Lowercase: c.Bool("lowercase"),
 			Numbers:   c.Bool("numbers"),
 			Special:   c.Bool("special"),
+			Min:       c.Int("min-length"),
 			Max:       c.Int("max-length"),
 		}
 

--- a/bruteforce/crack.go
+++ b/bruteforce/crack.go
@@ -20,6 +20,7 @@ type Strategy struct {
 	Uppercase bool
 	Numbers   bool
 	Special   bool
+	Min       int
 	Max       int
 }
 
@@ -53,16 +54,18 @@ func (b *Bruteforce) Crack(hash []byte, salt []byte, s *Strategy) *Result {
 
 	i := 1
 	for {
-		salted := append(curr, salt...)
-		x := s.Cipher.Hash(salted)
-		if bytes.Equal(hash, x) {
-			time := time.Now().Sub(start)
-			return &Result{
-				Ok:       true,
-				Hash:     hash,
-				Password: curr,
-				Tries:    i,
-				Time:     time,
+		if len(curr) >= s.Min {
+			salted := append(curr, salt...)
+			x := s.Cipher.Hash(salted)
+			if bytes.Equal(hash, x) {
+				time := time.Now().Sub(start)
+				return &Result{
+					Ok:       true,
+					Hash:     hash,
+					Password: curr,
+					Tries:    i,
+					Time:     time,
+				}
 			}
 		}
 

--- a/bruteforce/crack.go
+++ b/bruteforce/crack.go
@@ -52,9 +52,10 @@ func (b *Bruteforce) Crack(hash []byte, salt []byte, s *Strategy) *Result {
 	queue := [][]byte{}
 	var curr []byte
 
-	i := 1
+	i := 0
 	for {
 		if len(curr) >= s.Min {
+			i++
 			salted := append(curr, salt...)
 			x := s.Cipher.Hash(salted)
 			if bytes.Equal(hash, x) {
@@ -88,8 +89,6 @@ func (b *Bruteforce) Crack(hash []byte, salt []byte, s *Strategy) *Result {
 		if len(curr) > s.Max {
 			break
 		}
-
-		i++
 	}
 
 	// No match


### PR DESCRIPTION
- Add min-length flag for brute force method. Don't try to crack candidates with a shorter length.
- Don't use lowercase letters per default.